### PR TITLE
Add purchases list page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import PrivateRoute from "./routes/PrivateRoute";
 import UsersPage from "./pages/UsersPage";
 import HomePage from "./pages/HomePage";
 import UserFormPage from "./pages/UserFormPage";
+import PurchasesPage from "./pages/PurchasesPage";
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
@@ -44,6 +45,14 @@ export default function App() {
           element={
             <PrivateRoute>
               <UsersPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/purchases"
+          element={
+            <PrivateRoute>
+              <PurchasesPage />
             </PrivateRoute>
           }
         />

--- a/src/components/PurchaseList.tsx
+++ b/src/components/PurchaseList.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, CircularProgress } from '@mui/material';
+import { fetchPurchases } from '../services/purchaseService';
+import { Purchase } from '../types/purchaseTypes';
+
+const PurchaseList: React.FC = () => {
+  const [purchases, setPurchases] = useState<Purchase[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const { data } = await fetchPurchases();
+        setPurchases(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <Box mt={2}>
+      <Box sx={{ display: 'flex', borderRadius: 2, backgroundColor: '#0c1423', color: '#fff', px: 2, py: 1 }}>
+        <Typography sx={{ flex: 1 }}>Responsável</Typography>
+        <Typography>Total</Typography>
+      </Box>
+
+      {loading ? (
+        <Box py={4} textAlign="center">
+          <CircularProgress />
+        </Box>
+      ) : (
+        purchases.map((purchase) => (
+          <Box
+            key={purchase.id}
+            sx={{
+              backgroundColor: '#fff',
+              borderRadius: 2,
+              my: 1,
+              px: 2,
+              py: 1,
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography sx={{ color: '#00231d' }}>{purchase.responsavel}</Typography>
+            <Typography sx={{ color: '#00231d' }}>
+              {purchase.total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+            </Typography>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+};
+
+export default PurchaseList;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   People,
   ChevronLeft,
   ChevronRight,
+  ShoppingCart,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 
@@ -155,6 +156,31 @@ const Sidebar: React.FC<SidebarProps> = ({ open, toggleSidebar }) => {
             </ListItemButton>
           </List>
         </Collapse>
+        <ListItemButton
+          onClick={() => navigate('/purchases')}
+          sx={{
+            my: 0.5,
+            mx: 1,
+            borderRadius: 1,
+            backgroundColor: '#066b75',
+            minHeight: 36,
+            px: 1.5,
+            '& .MuiListItemIcon-root': {
+              color: '#fff',
+              minWidth: 32,
+            },
+            '& .MuiTypography-root': {
+              fontSize: '14px',
+              fontWeight: 500,
+              color: '#fff',
+            },
+          }}
+        >
+          <ListItemIcon>
+            <ShoppingCart fontSize="small" />
+          </ListItemIcon>
+          {open && <ListItemText primary="Compras" />}
+        </ListItemButton>
       </List>
 
 

--- a/src/pages/PurchasesPage.tsx
+++ b/src/pages/PurchasesPage.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import Sidebar from '../components/Sidebar';
+import Topbar from '../components/Topbar';
+import PurchaseList from '../components/PurchaseList';
+
+const PurchasesPage: React.FC = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  return (
+    <Box sx={{ display: 'flex', width: '100vw', height: '100vh', backgroundColor: '#F3F3F3' }}>
+      <Sidebar open={sidebarOpen} toggleSidebar={() => setSidebarOpen(!sidebarOpen)} />
+
+      <Box sx={{ width: '100%' }}>
+        <Topbar />
+
+        <Container maxWidth={false} disableGutters sx={{ mt: 2, px: 6 }}>
+          <Box pt={2}>
+            <Typography color="#0B2B25" fontWeight="bold" variant="h4">
+              Compras
+            </Typography>
+
+            <PurchaseList />
+          </Box>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default PurchasesPage;

--- a/src/services/purchaseService.ts
+++ b/src/services/purchaseService.ts
@@ -1,0 +1,12 @@
+import api from './api';
+import { FetchPurchasesResponse } from '../types/purchaseTypes';
+
+export const fetchPurchases = async (
+  page = 1,
+  limit = 10,
+): Promise<FetchPurchasesResponse> => {
+  const res = await api.get<FetchPurchasesResponse>('/purchases', {
+    params: { page, limit },
+  });
+  return res.data;
+};

--- a/src/types/purchaseTypes.ts
+++ b/src/types/purchaseTypes.ts
@@ -1,0 +1,11 @@
+export type Purchase = {
+  id: number;
+  total: number;
+  responsavel: string;
+  createdAt: Date;
+};
+
+export type FetchPurchasesResponse = {
+  data: Purchase[];
+  total: number;
+};


### PR DESCRIPTION
## Summary
- show new purchases page
- list purchases with responsible user and total
- add purchases entry in sidebar navigation

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c86e81fc832b8efcbd079e0591aa